### PR TITLE
Cantaloupe reverse proxy using IP

### DIFF
--- a/nginx-vhost.conf
+++ b/nginx-vhost.conf
@@ -28,6 +28,6 @@ server {
 
         # Settings for IA load balancer
         proxy_set_header Host cantaloupe.prod.archive.org; # So the LB knows what domain is being requested
-        proxy_pass https://207.241.239.241/ # IP of LB
+        proxy_pass https://207.241.239.241/iiif/$1/$2; # IP of LB
     }
 }

--- a/nginx-vhost.conf
+++ b/nginx-vhost.conf
@@ -11,22 +11,23 @@ server {
         alias /app/iiify/static;
     }
 
-    location ~ /iiif/image/([23])/(.*)$ {
-        rewrite ^ $request_uri;
-        rewrite ^/iiif/image/(2|3)/(.*)$ $2;
+    location ~ /image/iiif/([23])/(.*)$ {
+        rewrite ^ $request_uri; # Replace nginx $uri with the unescaped version
+        rewrite ^/image/iiif/(2|3)/(.*)$ /iiif/$1/$2 break; # capture and reformat the URI
+
+        # Settings to ensure Cantaloupe creates the right ids
+        # https://cantaloupe-project.github.io/manual/5.0/deployment.html#Reverse-Proxying
+        proxy_set_header X-Forwarded-Host iiif.archive.org;
+        proxy_set_header X-Forwarded-Path /image;
+        proxy_set_header X-Forwarded-For $remote_addr;
+
+        # CORS
         add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Methods' 'GET, HEAD, POST, PUT, PATCH, DELETE' always;
         add_header 'Access-Control-Expose-Headers' '*' always;
-        return 302 https://services-ia-iiif-cantaloupe-experiment.dev.archive.org/iiif/$1/$2;
-    }
 
-    location ~ /iiif/image/(.*)$ {
-        rewrite ^ $request_uri;
-        rewrite ^/iiif/image/(.*)$ $1;
-        add_header 'Access-Control-Allow-Origin' '*' always;
-        add_header 'Access-Control-Allow-Methods' 'GET, HEAD, POST, PUT, PATCH, DELETE' always;
-        add_header 'Access-Control-Expose-Headers' '*' always;
-        return 302 https://services-ia-iiif-cantaloupe-experiment.dev.archive.org/iiif/3/$1;
+        # Settings for IA load balancer
+        proxy_set_header Host cantaloupe.prod.archive.org; # So the LB knows what domain is being requested
+        proxy_pass https://207.241.239.241/ # IP of LB
     }
-
 }


### PR DESCRIPTION
This adds the reverse proxy to Cantaloupe based on using the IP address of the IA load balancer and passing the target domain explicitly as a header.

Pro: Doesn't require resolving the address of the LB/Cantaloupe server on every request -> less unnecessary traffic
Con: Hard codes IP address of the Load Balancer, so will stop working if that changes

NB: Only one of this or #3 should be merged, followed by #4 to update the address used in manifest generation