### PR TITLE
Cantaloupe reverse proxy using resolver

### DIFF
--- a/nginx-vhost.conf
+++ b/nginx-vhost.conf
@@ -1,3 +1,6 @@
+# Set the resolver required by nginx for reverse-proxy lookups when using variables
+resolver 9.9.9.9:53; # TODO: Change this to internal IA resolver
+
 server {
     listen 8080;
     location / {
@@ -11,22 +14,23 @@ server {
         alias /app/iiify/static;
     }
 
-    location ~ /iiif/image/([23])/(.*)$ {
-        rewrite ^ $request_uri;
-        rewrite ^/iiif/image/(2|3)/(.*)$ $2;
-        add_header 'Access-Control-Allow-Origin' '*' always;
-        add_header 'Access-Control-Allow-Methods' 'GET, HEAD, POST, PUT, PATCH, DELETE' always;
-        add_header 'Access-Control-Expose-Headers' '*' always;
-        return 302 https://services-ia-iiif-cantaloupe-experiment.dev.archive.org/iiif/$1/$2;
-    }
+    location ~ /image/iiif/([23])/(.*)$ {
+        rewrite ^ $request_uri; # Replace nginx $uri with the unescaped version
+        rewrite ^/image/iiif/(2|3)/(.*)$ /iiif/$1/$2 break; # capture and reformat the URI
 
-    location ~ /iiif/image/(.*)$ {
-        rewrite ^ $request_uri;
-        rewrite ^/iiif/image/(.*)$ $1;
+        # Settings to ensure Cantaloupe creates the right ids
+        # https://cantaloupe-project.github.io/manual/5.0/deployment.html#Reverse-Proxying
+        proxy_set_header X-Forwarded-Host iiif.archive.org;
+        proxy_set_header X-Forwarded-Path /image;
+        proxy_set_header X-Forwarded-For $remote_addr;
+
+        # CORS
         add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Methods' 'GET, HEAD, POST, PUT, PATCH, DELETE' always;
         add_header 'Access-Control-Expose-Headers' '*' always;
-        return 302 https://services-ia-iiif-cantaloupe-experiment.dev.archive.org/iiif/3/$1;
+
+        # Reverse proxy with the variables captured above
+        proxy_pass https://cantaloupe.prod.archive.org/iiif/$1/$2;
     }
 
 }


### PR DESCRIPTION
This adds the reverse proxy to Cantaloupe based on using an external (to the nginx process / the container) to look up the IP address of the Cantaloupe server. The nginx config is currently configured to use the Quad9 resolver, but this can/should be changed before deploy as per the IA's preferences.

Pro: Cantaloupe can be freely moved around (e.g on and off load balancer, to a different load balancer, to an internal-only domain, etc).
Con: Due to quirks in how nginx works, the target domain will be re-resolved on every request -> more traffic

NB: Only one of this or #2 should be merged, followed by #4 to update the address used in manifest generation
