### PR TITLE
Update the URL of the image server to be the reverse proxy address

### DIFF
--- a/iiify/configs/__init__.py
+++ b/iiify/configs/__init__.py
@@ -66,7 +66,7 @@ s3key = config.getdef('url2iiif', 's3key', '')
 s3secret = config.getdef('url2iiif', 's3secret', '')
 
 # cantaloupe server
-image_server = config.getdef('cantaloupe', 'url', 'https://cantaloupe.prod.archive.org/iiif')
+image_server = config.getdef('cantaloupe', 'url', 'https://iiif.archive.org/image/iiif')
 
 # caching
 cache_timeouts = {


### PR DESCRIPTION
Once either #2 or #3 is merged, we should start using the reverse-proxied `iiif.archive.org/image` address in the generated Manifests.