### PR TITLE
Enable Flask-CORS by default and update Cantaloupe default

### DIFF
--- a/iiify/app.py
+++ b/iiify/app.py
@@ -232,7 +232,7 @@ def add_header(response):
 
 def ldjsonify(data):
     j = jsonify(data)
-    j.headers.set('Access-Control-Allow-Origin', '*')
+    # j.headers.set('Access-Control-Allow-Origin', '*')
     j.mimetype = "application/ld+json"
     return j
 

--- a/iiify/app.py
+++ b/iiify/app.py
@@ -206,7 +206,9 @@ def manifest2(identifier):
         page = int(page)
     try:
         return ldjsonify(create_manifest(identifier, domain=domain, page=page))
-    except:
+    except Exception as excpt:
+        print("Exception occurred in manifest2:")
+        print(excpt)
         abort(404)
 
 

--- a/iiify/configs/__init__.py
+++ b/iiify/configs/__init__.py
@@ -41,7 +41,7 @@ if CRT and KEY:
 
 # Enable CORS to allow cross-domain loading of tilesets from this server
 # Especially useful for SeaDragon viewers running locally
-cors = bool(int(config.getdef('server', 'cors', 0)))
+cors = bool(int(config.getdef('server', 'cors', 1)))
 
 iiif_domain = config.getdef('server', 'domain', 'https://iiif.archivelab.org')
 media_root = config.getdef('media', 'root', 'media')

--- a/iiify/configs/__init__.py
+++ b/iiify/configs/__init__.py
@@ -66,7 +66,7 @@ s3key = config.getdef('url2iiif', 's3key', '')
 s3secret = config.getdef('url2iiif', 's3secret', '')
 
 # cantaloupe server
-image_server = config.getdef('cantaloupe', 'url', 'https://iiif.prod.archive.org/image/iiif')
+image_server = config.getdef('cantaloupe', 'url', 'https://iiif.archive.org/image/iiif')
 
 # caching
 cache_timeouts = {

--- a/tests/test_manifests_v2.py
+++ b/tests/test_manifests_v2.py
@@ -19,6 +19,6 @@ class TestManifests(unittest.TestCase):
 
 
     def test_text_which_is_image(self):
-        resp = self.test_app.get("/iiif/2/z-2-2-18-14-9/manifest.json")    
+        resp = self.test_app.get("/iiif/2/fbf_3chords_1_/manifest.json")
 
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
Fixes the issues with redirects of v2 images.

The v2 code is still pointing at the old archivelabs service for images, and we should probably change that at some point, but it's a separate issue.

Closes #24 