### PR TITLE
suggested fix for v2 manifest creation: changed domain in manifest2 creation

### DIFF
--- a/iiify/app.py
+++ b/iiify/app.py
@@ -199,7 +199,7 @@ def manifest(identifier):
 
 @app.route('/iiif/2/<identifier>/manifest.json')
 def manifest2(identifier):
-    domain = "https://iiif.archivelab.org/iiif/"
+    domain = "https://iiif.archive.org/iiif/"
     page = None
     if '$' in identifier:
         identifier, page = identifier.split('$')


### PR DESCRIPTION
this is probably too simplistic, but since the iiif.archive.org is still working, it seems like changing the domain value would fix the problem. 

Of course now all your old v2 ids won't be the same, so it may not be a good solution.

I'm also note very familiar with the code base, so I could be way off, but this seemed like the source of the trouble. 
I just wanted to make the spot for the issue. Please feel free to close whenever.

