### PR TITLE
Add mime/type for h.264 HD based on output from file utility.

### DIFF
--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -134,6 +134,7 @@ def to_mimetype(format):
         "HiRes MPEG4": "video/mpeg",
         "h.264 MPEG4": "video/mpeg",
         "h.264": "video/mpeg",
+        "h.264 HD": "video/mp4",
         "Matroska": "video/x-matroska",
         "Cinepack": "video/x-msvideo",
         "AIFF": "audio/aiff",


### PR DESCRIPTION
# What Does this Do

This addresses [Issue 82](https://github.com/internetarchive/iiif/issues/82) by selecting a valid mime-type for `h264 HD` files. The mime-type used is based on the output of the file utility:

```
file --mime-type ~/Downloads/Polar_Plunge_Promo_-_2018.HD.mov

/Users/mark.baggett/Downloads/Polar_Plunge_Promo_-_2018.HD.mov: video/mp4
```

Here is the results of the change in a variety of viewers:

  * [RAMP](https://ramp.avalonmediasystem.org/?iiif-content=https://markpbaggett.github.io/static_iiif/manifests/ia_tests/polar_plunge_verify.json)
  * [Theseus](https://theseus-viewer.netlify.app/?iiif-content=https://markpbaggett.github.io/static_iiif/manifests/ia_tests/polar_plunge_verify.json)
  * [UV](https://uv-v4.netlify.app/#?manifest=https://markpbaggett.github.io/static_iiif/manifests/ia_tests/polar_plunge_verify.json&c=&m=&cv=&xywh=)
  * [Mirador](https://projectmirador.org/embed/?iiif-content=https://markpbaggett.github.io/static_iiif/manifests/ia_tests/polar_plunge_verify.json)
  * [Clover](https://samvera-labs.github.io/clover-iiif/docs/viewer/demo?iiif-content=https%3A%2F%2Fmarkpbaggett.github.io%2Fstatic_iiif%2Fmanifests%2Fia_tests%2Fpolar_plunge_verify.json) 