### PR TITLE
Adding support for audio items with no derivatives

### DIFF
--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -703,7 +703,12 @@ def create_manifest3(identifier, domain=None, page=None):
                         body.items.append(r)
             else:
                 # todo: deal with instances where there are no derivatives for whatever reason
-                pass
+                body = ResourceItem(
+                            id=f"https://archive.org/download/{identifier}/{file['name'].replace(' ', '%20')}",
+                            type='Sound',
+                            format=to_mimetype(file['format']),
+                            label={"none": [file['format']]},
+                            duration=float(file['length']))
 
             anno.body = body
             ap.add_item(anno)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,19 @@
+import os
+
+import unittest
+import math
+from flask.testing import FlaskClient
+from iiify.app import app
+
+class TestAudio(unittest.TestCase):
+
+    def setUp(self) -> None:
+        os.environ["FLASK_CACHE_DISABLE"] = "true"
+        self.test_app = FlaskClient(app)
+
+    def test_audio_no_derivatives(self):
+        resp = self.test_app.get("/iiif/3/kaled_jalil/manifest.json")
+        self.assertEqual(resp.status_code, 200)
+        manifest = resp.json
+
+        self.assertEqual(len(manifest['items']),114,f"Expected 114 canvases but got: {len(manifest['items'])}") 


### PR DESCRIPTION
I'm getting 403 errors for the example in #54. I can open the following URL in the browser:

https://archive.org/download/kaled_jalil/001.mp3

but if I try to curl it:

```
curl -Lv https://archive.org/download/kaled_jalil/001.mp3 > /dev/null
HTTP/2 302 
< location: https://ia601903.us.archive.org/27/items/kaled_jalil/001.mp3
< access-control-allow-origin: *

< HTTP/2 403 
< server: nginx/1.24.0
< date: Thu, 06 Feb 2025 21:30:07 GMT
< content-type: text/html; charset=utf-8
< content-length: 4741
< etag: "67526a7b-1285"
< strict-transport-security: max-age=15724800
```

but the manifest seems to be working and is valid. 

 