### PR TITLE
Addressing Issue 101.

### DIFF
--- a/iiify/app.py
+++ b/iiify/app.py
@@ -230,7 +230,7 @@ def manifest2(identifier):
         identifier, page = identifier.split('$')
         page = int(page)
     try:
-        return ldjsonify(create_manifest(identifier, domain=domain, page=page))
+        return ldjsonify(create_manifest(identifier, domain=domain, page=page, version='2/'))
     except Exception as excpt:
         print("Exception occurred in manifest2:")
         print(excpt)

--- a/iiify/app.py
+++ b/iiify/app.py
@@ -171,14 +171,14 @@ def collection3page(identifier, page):
 @cache.cached(timeout=cache_timeouts["long"], forced_update=cache_bust)
 def collectionJSON(identifier):
     validate_ia_identifier(identifier, page_suffix=False)
-    return redirect(f'/iiif/3/{identifier}/collection.json', code=302)
+    return collection3JSON(identifier)
 
 
 @app.route('/iiif/<identifier>/<page>/collection.json')
 @cache.cached(timeout=cache_timeouts["long"], forced_update=cache_bust)
 def collectionPage(identifier, page):
     validate_ia_identifier(identifier, page_suffix=False)
-    return redirect(f'/iiif/3/{identifier}/{page}/collection.json', code=302)
+    return collection3page(identifier, page)
 
 
 @app.route('/iiif/3/<identifier>/manifest.json')
@@ -219,7 +219,7 @@ def vtt_stream(identifier):
 @cache.cached(timeout=cache_timeouts["long"], forced_update=cache_bust)
 def manifest(identifier):
     validate_ia_identifier(identifier, page_suffix=False)
-    return redirect(f'/iiif/3/{identifier}/manifest.json', code=302)
+    return manifest3(identifier)
 
 @app.route('/iiif/2/<identifier>/manifest.json')
 def manifest2(identifier):

--- a/iiify/app.py
+++ b/iiify/app.py
@@ -230,7 +230,7 @@ def manifest2(identifier):
         identifier, page = identifier.split('$')
         page = int(page)
     try:
-        return ldjsonify(create_manifest(identifier, domain=domain, page=page, version='2/'))
+        return ldjsonify(create_manifest(identifier, domain=domain, page=page))
     except Exception as excpt:
         print("Exception occurred in manifest2:")
         print(excpt)

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -236,14 +236,14 @@ def manifest_page(identifier, label='', page='', width='', height='', metadata=N
     }
 
 
-def create_manifest(identifier, domain=None, page=None):
+def create_manifest(identifier, domain=None, page=None, version=""):
     path = os.path.join(media_root, identifier)
     resp = requests.get('%s/metadata/%s' % (ARCHIVE, identifier)).json()
     metadata = resp.get("metadata", {})
 
     manifest = {
         '@context': PRZ_CTX,
-        '@id': '%s%s/manifest.json' % (domain, identifier),
+        '@id': '%s%s%s/manifest.json' % (domain, version, identifier),
         '@type': 'sc:Manifest',
         'description': metadata.get('description', ''),
         'logo': 'https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcReMN4l9cgu_qb1OwflFeyfHcjp8aUfVNSJ9ynk2IfuHwW1I4mDSw',

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -236,14 +236,14 @@ def manifest_page(identifier, label='', page='', width='', height='', metadata=N
     }
 
 
-def create_manifest(identifier, domain=None, page=None, version=""):
+def create_manifest(identifier, domain=None, page=None):
     path = os.path.join(media_root, identifier)
     resp = requests.get('%s/metadata/%s' % (ARCHIVE, identifier)).json()
     metadata = resp.get("metadata", {})
 
     manifest = {
         '@context': PRZ_CTX,
-        '@id': '%s%s%s/manifest.json' % (domain, version, identifier),
+        '@id': '%s2/%s/manifest.json' % (domain,identifier),
         '@type': 'sc:Manifest',
         'description': metadata.get('description', ''),
         'logo': 'https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcReMN4l9cgu_qb1OwflFeyfHcjp8aUfVNSJ9ynk2IfuHwW1I4mDSw',

--- a/iiify/templates/docs/collections.html
+++ b/iiify/templates/docs/collections.html
@@ -14,10 +14,10 @@
 <pre>leedsuniversitylibrary</pre>
 
     <p>To then get the IIIF collection manifest, plug in the ID to the following template:</p>
-    <div class="request">https://iiif.archive.org/iiif/3/<b>:id</b>/collection.json</div>
+    <div class="request">https://iiif.archive.org/iiif/<b>:id</b>/collection.json</div>
 
     <p>For the Leeds example above, the final IIIF collection manifest URL would be:</p>
-    <div class="request">https://iiif.archive.org/iiif/3/leedsuniversitylibrary/collection.json</div>
+    <div class="request">https://iiif.archive.org/iiif/leedsuniversitylibrary/collection.json</div>
 
 <h3>Note about nested collections</h3>
 <p>Please note that Internet Archive collections can be arbitrarily nested within other collections. In these cases, the IIIF collection manifest will return a link to one or more IIIF collection manifest(s) in addition to the items nested individually within that Internet Archive collection.</p>
@@ -34,10 +34,10 @@
 
 <table>
   <thead><td>Collection manifest URL</td><td>Items retrieved</td></thead>
-  <tr><td>https://iiif.archive.org/iiif/3/leedsuniversitylibrary/collection.json</td><td>0-999</td></tr>
-  <tr><td>https://iiif.archive.org/iiif/3/leedsuniversitylibrary/2/collection.json</td><td>1000-1999</td></tr>
-  <tr><td>https://iiif.archive.org/iiif/3/leedsuniversitylibrary/3/collection.json</td><td>2000-2999</td></tr>
-  <tr><td>https://iiif.archive.org/iiif/3/leedsuniversitylibrary/4/collection.json</td><td>3000-3775</td></tr>
+  <tr><td>https://iiif.archive.org/iiif/leedsuniversitylibrary/collection.json</td><td>0-999</td></tr>
+  <tr><td>https://iiif.archive.org/iiif/leedsuniversitylibrary/2/collection.json</td><td>1000-1999</td></tr>
+  <tr><td>https://iiif.archive.org/iiif/leedsuniversitylibrary/3/collection.json</td><td>2000-2999</td></tr>
+  <tr><td>https://iiif.archive.org/iiif/leedsuniversitylibrary/4/collection.json</td><td>3000-3775</td></tr>
   </table>
   </section>
 </article>

--- a/iiify/templates/docs/items.html
+++ b/iiify/templates/docs/items.html
@@ -39,10 +39,10 @@
     <p>So, from our example just above, the Internet Archive identifier for that item is: <pre>img-8664_202009</pre></p>
 
     <p>To then get the IIIF manifest, plug in the ID to the following template:</p>
-    <div class="request">https://iiif.archive.org/iiif/3/<b>:id</b>/manifest.json</div>
+    <div class="request">https://iiif.archive.org/iiif/<b>:id</b>/manifest.json</div>
 
     <p>For the example above, the final IIIF manifest URL would be:</p>
-    <div class="request">https://iiif.archive.org/iiif/3/img-8664_202009/manifest.json</div>
+    <div class="request">https://iiif.archive.org/iiif/img-8664_202009/manifest.json</div>
 
 <h3>Note about IIIF Presentation API versions</h3>
 <p>

--- a/iiify/templates/docs/overview.html
+++ b/iiify/templates/docs/overview.html
@@ -15,7 +15,7 @@
       emphasis:
     </p>
 
-    <div class="request">https://iiif.archive.org/iiif/3/<strong>:id</strong>/manifest.json</div>    
+    <div class="request">https://iiif.archive.org/iiif/<strong>:id</strong>/manifest.json</div>    
   </section>
 
 <h2>Getting started</h2>
@@ -45,7 +45,7 @@
       <p>The Presentation API can also faciliate the portability and playback of time-based media like audio and video files. In the A/V context, IIIF manifests often present multiple playback options based on the media formats and quality types available.</p>
       
       <p>A manifest for an Internet Archive item looks like this:</p>
-    <div class="request">https://iiif.archive.org/iiif/3/<b>:id</b>/manifest.json</div>
+    <div class="request">https://iiif.archive.org/iiif/<b>:id</b>/manifest.json</div>
 
           <p>See the sections below for all the possible ways to retrieve manifests for <a href="#items">items</a> and <a href="#collections">collections</a>.</p>
 
@@ -66,10 +66,10 @@
     <p>The Image API creates images using the following template: </p>
       <div class="request">{scheme}://{server}/{prefix}/{identifier}/{region}/{size}/{rotation}/{quality}.{format}</div>
     <p>In the context of the Internet Archive items, that will look like this for a full image:</p>
-    <div class="request">https://iiif.archive.org/image/iiif/3/<b>:id+filename</b>/full/max/0/default.jpg</div>
+    <div class="request">https://iiif.archive.org/image/iiif/<b>:id+filename</b>/full/max/0/default.jpg</div>
 
     <p>Making use of the various parameters, a request for a bitonal center-cropped square image 375 pixels on each side, rotated 45 degrees will look like this:</p>
-    <div class="request">https://iiif.archive.org/image/iiif/3/<b>:id+filename</b>/square/375,/45/bitonal.jpg</div>
+    <div class="request">https://iiif.archive.org/image/iiif/<b>:id+filename</b>/square/375,/45/bitonal.jpg</div>
 
     <p>See the <a href="https://iiif.io/api/image/3.0/#4-image-requests">Image API section on "Image Requests"</a> for more details on how images can be manipulated and specific sizes or sections retrieved.</p>
 
@@ -90,11 +90,11 @@
 <p>In order to get the :id+filename the way you need it for the IIIF Image API info.json, you can combine the ID and filename with a URL encoded slash, i.e. %2f.</p>
 
 <p>So for this image, the info.json would be:</p>
-<div class="request">https://iiif.archive.org/image/iiif/3/img-8664_202009%2fIMG_8664.jpg/info.json</div>
+<div class="request">https://iiif.archive.org/image/iiif/img-8664_202009%2fIMG_8664.jpg/info.json</div>
 <p>And the full URL for the image would be:</p>
-<div class="request">https://iiif.archive.org/image/iiif/3/img-8664_202009%2fIMG_8664.jpg/full/max/0/default.jpg</div>
+<div class="request">https://iiif.archive.org/image/iiif/img-8664_202009%2fIMG_8664.jpg/full/max/0/default.jpg</div>
 <p>A cropped portion at the full resolution can be requested like this:</p>
-<div class="request">https://iiif.archive.org/image/iiif/3/img-8664_202009%2fIMG_8664.jpg/<b>1100,904,704,664</b>/max/0/default.jpg</div>
+<div class="request">https://iiif.archive.org/image/iiif/img-8664_202009%2fIMG_8664.jpg/<b>1100,904,704,664</b>/max/0/default.jpg</div>
 <p>Where "1100,904,704,664" in that URL stands for 1100 pixels from the left edge, 904 pixels from the bottom edge, 704 pixels is the width of the desired section, and 664 pixels is the height.</p>
 
 

--- a/iiify/templates/helper.html
+++ b/iiify/templates/helper.html
@@ -17,9 +17,9 @@
 
 <p>The manifest URL is: <a href="{{ uri }}/manifest.json">{{ uri }}/manifest.json</a></p>
 
-<p>The Image API URL for the full image is: <a href="https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/full/max/0/default.jpg">https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/full/max/0/default.jpg</a></p>
+<p>The Image API URL for the full image is: <a href="https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/full/max/0/default.jpg">https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/full/max/0/default.jpg</a></p>
 
-<p>The Image API info.json  for the image is: <a href="https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/info.json">https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/info.json</a></p>
+<p>The Image API info.json  for the image is: <a href="https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/info.json">https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/info.json</a></p>
 
     </body>
 </html>

--- a/iiify/templates/helpers/audio.html
+++ b/iiify/templates/helpers/audio.html
@@ -25,15 +25,15 @@
 
 <p>The IA identifier is: {{ identifier }}</p>
 
-<p>The IIIF manifest URL is: <a href="https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json</a></p>
+<p>The IIIF manifest URL is: <a href="https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json</a></p>
 
 <h2>IIIF player options for this mediatype:</h2>
 <ul>
-    <li><a href="https://uv-v4.netlify.app/#?manifest=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Universal Viewer</a></li>
-    <li><a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Mirador comparison viewer/player</a></li>
-    <li><a href="https://iiif-react-media-player.netlify.app//?iiif-content=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Ramp</a></li>
-    <li><a href="https://iiif.aviaryplatform.com/player?manifest=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Aviary</a></li>
-    <li><a href="https://samvera-labs.github.io/clover-iiif?iiif-content=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Clover</a></li>
+    <li><a href="https://uv-v4.netlify.app/#?manifest=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Universal Viewer</a></li>
+    <li><a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Mirador comparison viewer/player</a></li>
+    <li><a href="https://iiif-react-media-player.netlify.app//?iiif-content=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Ramp</a></li>
+    <li><a href="https://iiif.aviaryplatform.com/player?manifest=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Aviary</a></li>
+    <li><a href="https://samvera-labs.github.io/clover-iiif?iiif-content=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Clover</a></li>
 
 </ul>
 

--- a/iiify/templates/helpers/collection.html
+++ b/iiify/templates/helpers/collection.html
@@ -24,13 +24,13 @@
 
 <p>The IA identifier is: {{ identifier }}</p>
 
-<p>The IIIF collection URL is: <a href="https://iiif.archive.org/iiif/3/{{ identifier }}/collection.json">https://iiif.archive.org/iiif/3/{{ identifier }}/collection.json</a></p>
+<p>The IIIF collection URL is: <a href="https://iiif.archive.org/iiif/{{ identifier }}/collection.json">https://iiif.archive.org/iiif/{{ identifier }}/collection.json</a></p>
 
 <h2>IIIF viewer options</h2>
 <ul>
-    <li><a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/3/{{ identifier }}/collection.json">Mirador</a></li>
-    <li><a href="https://uv-v4.netlify.app/#?manifest=https://iiif.archive.org/iiif/3/{{ identifier }}/collection.json">Universal Viewer</a></li>
-    <li><a href="https://samvera-labs.github.io/clover-iiif?iiif-content=https://iiif.archive.org/iiif/3/{{ identifier }}/collection.json">Clover</a></li>
+    <li><a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/{{ identifier }}/collection.json">Mirador</a></li>
+    <li><a href="https://uv-v4.netlify.app/#?manifest=https://iiif.archive.org/iiif/{{ identifier }}/collection.json">Universal Viewer</a></li>
+    <li><a href="https://samvera-labs.github.io/clover-iiif?iiif-content=https://iiif.archive.org/iiif/{{ identifier }}/collection.json">Clover</a></li>
 
 </ul>
 

--- a/iiify/templates/helpers/image.html
+++ b/iiify/templates/helpers/image.html
@@ -24,25 +24,25 @@
 
 <p>The IA identifier is: {{ identifier }}</p>
 
-<p>The IIIF manifest URL is: <a href="https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json</a></p>
+<p>The IIIF manifest URL is: <a href="https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">https://iiif.archive.org/iiif/{{ identifier }}/manifest.json</a></p>
 
-<p>The Image API URL for the full image is: <a href="https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/full/max/0/default.jpg">https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/full/max/0/default.jpg</a></p>
+<p>The Image API URL for the full image is: <a href="https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/full/max/0/default.jpg">https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/full/max/0/default.jpg</a></p>
 
-<p>The Image API info.json  for the image is: <a href="https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/info.json">https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/info.json</a></p>
+<p>The Image API info.json  for the image is: <a href="https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/info.json">https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/info.json</a></p>
 
 <h2>IIIF viewer options</h2>
 <ul>
-    <li><a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Mirador</a></li>
-    <li><a href="https://uv-v4.netlify.app/#?manifest=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Universal Viewer</a></li>
-    <li><a href="https://samvera-labs.github.io/clover-iiif?iiif-content=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Clover</a></li>
+    <li><a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Mirador</a></li>
+    <li><a href="https://uv-v4.netlify.app/#?manifest=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Universal Viewer</a></li>
+    <li><a href="https://samvera-labs.github.io/clover-iiif?iiif-content=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Clover</a></li>
 
 </ul>
 
 <h2>IIIF image tool options</h2>
 <ul>
-  <li><a href="https://iiifimage.link/#https://iiif.archive.org/image/iiif/3/{{ esc_cantaloupe_id }}/full/max/0/default.jpg">IIIF Image Inspector</a></li>
+  <li><a href="https://iiifimage.link/#https://iiif.archive.org/image/iiif/{{ esc_cantaloupe_id }}/full/max/0/default.jpg">IIIF Image Inspector</a></li>
   <li><a href="https://ncsu-libraries.github.io/iiif-crop-tool/?newUrl=https://iiif.archive.org/image/iiif/2/{{ esc_cantaloupe_id }}/full/full/0/default.jpg">NC State Image Cropper</a></li>
-  <li><a href="https://jbhoward-dublin.github.io/IIIF-imageManipulation/index.html?imageID=https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}">IIIF Image Manipulation Tool</a></li>
+  <li><a href="https://jbhoward-dublin.github.io/IIIF-imageManipulation/index.html?imageID=https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}">IIIF Image Manipulation Tool</a></li>
   <li><a href="https://glenrobson.github.io/CanvasFinder/">CanvasFinder (Note: paste in the manifest URL noted above)</a></li>
 </ul>
 

--- a/iiify/templates/helpers/movies.html
+++ b/iiify/templates/helpers/movies.html
@@ -24,15 +24,15 @@
 
 <p>The IA identifier is: {{ identifier }}</p>
 
-<p>The IIIF manifest URL is: <a href="https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json</a></p>
+<p>The IIIF manifest URL is: <a href="https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">https://iiif.archive.org/iiif/{{ identifier }}/manifest.json</a></p>
 
 <h2>IIIF viewer options for this mediatype:</h2>
 <ul>
-    <li><a href="https://uv-v4.netlify.app/#?manifest=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Universal Viewer</a></li>
-    <li><a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Mirador comparison viewer</a></li>
-    <li><a href="https://iiif-react-media-player.netlify.app//?iiif-content=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Ramp</a></li>
-    <li><a href="https://iiif.aviaryplatform.com/player?manifest=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Aviary</a></li>
-    <li><a href="https://samvera-labs.github.io/clover-iiif?iiif-content=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Clover</a></li>
+    <li><a href="https://uv-v4.netlify.app/#?manifest=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Universal Viewer</a></li>
+    <li><a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Mirador comparison viewer</a></li>
+    <li><a href="https://iiif-react-media-player.netlify.app//?iiif-content=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Ramp</a></li>
+    <li><a href="https://iiif.aviaryplatform.com/player?manifest=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Aviary</a></li>
+    <li><a href="https://samvera-labs.github.io/clover-iiif?iiif-content=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Clover</a></li>
 
 </ul>
 

--- a/iiify/templates/helpers/texts.html
+++ b/iiify/templates/helpers/texts.html
@@ -24,13 +24,13 @@
 
 <p>The IA identifier is: {{ identifier }}</p>
 
-<p>The IIIF manifest URL is: <a href="https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json</a></p>
+<p>The IIIF manifest URL is: <a href="https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">https://iiif.archive.org/iiif/{{ identifier }}/manifest.json</a></p>
 
 <h2>IIIF Viewer options for this mediatype:</h2>
 <ul>
-    <li><a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Mirador</a></li>
-    <li><a href="https://uv-v4.netlify.app/#?manifest=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Universal Viewer</a></li>
-    <li><a href="https://samvera-labs.github.io/clover-iiif?iiif-content=https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">Clover</a></li>
+    <li><a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Mirador</a></li>
+    <li><a href="https://uv-v4.netlify.app/#?manifest=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Universal Viewer</a></li>
+    <li><a href="https://samvera-labs.github.io/clover-iiif?iiif-content=https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">Clover</a></li>
 </ul>
 
     </body>

--- a/iiify/templates/helpers/unknown.html
+++ b/iiify/templates/helpers/unknown.html
@@ -24,7 +24,7 @@
 
 <p>The IA identifier is: {{ identifier }}</p>
 
-<p>The IIIF manifest URL is: <a href="https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json">https://iiif.archive.org/iiif/3/{{ identifier }}/manifest.json</a></p>
+<p>The IIIF manifest URL is: <a href="https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">https://iiif.archive.org/iiif/{{ identifier }}/manifest.json</a></p>
 
 <p>The material type of the item you're requested is not a recognized material type for IIIF viewers.</p>
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -6,7 +6,7 @@ from iiify.app import app
 class TestCollections(unittest.TestCase):
 
     def setUp(self) -> None:
-        os.environ["FLASK_ENV"] = "testing"
+        os.environ["FLASK_CACHE_DISABLE"] = "true"
         self.test_app = FlaskClient(app)
 
     def test_v3_collection(self):
@@ -24,7 +24,6 @@ class TestCollections(unittest.TestCase):
 
     def test_collections_proxy(self):
         resp = self.test_app.get("/iiif/frankbford/collection.json")
-        print(resp.status_code)
         self.assertEqual(resp.status_code, 200)
 
     def test_v3_collection_pages_proxy(self):

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -22,13 +22,14 @@ class TestCollections(unittest.TestCase):
         resp = self.test_app.get("/iiif/3/frankbford/2/collection.json")
         self.assertEqual(resp.status_code, 200)
 
-    def test_collections_redirect(self):
+    def test_collections_proxy(self):
         resp = self.test_app.get("/iiif/frankbford/collection.json")
-        self.assertEqual(resp.status_code, 302)
+        print(resp.status_code)
+        self.assertEqual(resp.status_code, 200)
 
-    def test_v3_collection_pages_redirect(self):
-            resp = self.test_app.get("/iiif/frankbford/2/collection.json")
-            self.assertEqual(resp.status_code, 302)
+    def test_v3_collection_pages_proxy(self):
+        resp = self.test_app.get("/iiif/frankbford/2/collection.json")
+        self.assertEqual(resp.status_code, 200)
 
 def test_v3_collection_detection(self):
         resp = self.test_app.get("/iiif/frankbford/manifest.json")

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -14,10 +14,10 @@ class TestHelper(unittest.TestCase):
         resp = self.test_app.get("/iiif/helper/img-8664_202009/")
         self.assertEqual(resp.status_code, 200)
 
-        self.assertIn('<a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/3/img-8664_202009/manifest.json">Mirador</a>', resp.text, "Couldn't find Mirador link in helper page.")
+        self.assertIn('<a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/img-8664_202009/manifest.json">Mirador</a>', resp.text, "Couldn't find Mirador link in helper page.")
 
     def test_collection(self):
         resp = self.test_app.get("/iiif/helper/frankbford/")
         self.assertEqual(resp.status_code, 200)
 
-        self.assertIn('<a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/3/frankbford/collection.json">Mirador</a>', resp.text, "Couldn't find Mirador link in helper page.")
+        self.assertIn('<a href="https://projectmirador.org/embed/?iiif-content=https://iiif.archive.org/iiif/frankbford/collection.json">Mirador</a>', resp.text, "Couldn't find Mirador link in helper page.")

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -7,7 +7,7 @@ from iiify.app import app
 class TestImages(unittest.TestCase):
 
     def setUp(self) -> None:
-        os.environ["FLASK_ENV"] = "testing"
+        os.environ["FLASK_CACHE_DISABLE"] = "true"
         self.test_app = FlaskClient(app)
 
     def test_v3_resolving(self):

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -12,8 +12,7 @@ class TestManifests(unittest.TestCase):
 
     def test_no_version(self):
         resp = self.test_app.get("/iiif/rashodgson68/manifest.json")
-        self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp.location, '/iiif/3/rashodgson68/manifest.json')
+        self.assertEqual(resp.status_code, 200)
 
     def test_ident(self):
         resp = self.test_app.get("/iiif/3/img-8664_202009/manifest.json")

--- a/tests/test_manifests_v2.py
+++ b/tests/test_manifests_v2.py
@@ -15,7 +15,7 @@ class TestManifests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         manifest = resp.json
 
-        self.assertEqual(manifest['@id'], 'https://localhost/iiif/rashodgson68/manifest.json', 'V2 Manifest ID is using new infrastructure changed')
+        self.assertEqual(manifest['@id'], 'https://localhost/iiif/2/rashodgson68/manifest.json', 'V2 Manifest ID is using new infrastructure changed')
         self.assertEqual(manifest['@type'], "sc:Manifest", f"Unexpected type. Expected Manifest got {manifest['@type']}")
         self.assertEqual(len(manifest['sequences'][0]['canvases']),32,f"Expected 32 canvases but got: {len(manifest['sequences'][0]['canvases'])}")
         self.assertEqual(manifest['sequences'][0]['canvases'][0]['@id'],"https://iiif.archivelab.org/iiif/rashodgson68$0/canvas",f"v2 canvas id has changed")
@@ -26,7 +26,7 @@ class TestManifests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         manifest = resp.json
 
-        self.assertEqual(manifest['@id'], 'https://localhost/iiif/1991-12-compute-magazine/manifest.json', 'V2 Manifest ID is using new infrastructure changed')
+        self.assertEqual(manifest['@id'], 'https://localhost/iiif/2/1991-12-compute-magazine/manifest.json', 'V2 Manifest ID is using new infrastructure changed')
         image = manifest['sequences'][0]['canvases'][0]['images'][0]['resource']
         self.assertEqual(image['@id'], "https://localhost/iiif/1991-12-compute-magazine$0/full/full/0/default.jpg", "Resource not using new image server")
         self.assertEqual(image['service']['@id'], 'https://localhost/iiif/1991-12-compute-magazine$0', "V2 service not using the new image server")
@@ -36,7 +36,7 @@ class TestManifests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         manifest = resp.json
 
-        self.assertEqual(manifest['@id'], 'https://localhost/iiif/img-8664_202009/manifest.json', 'V2 Manifest ID is using new infrastructure changed')
+        self.assertEqual(manifest['@id'], 'https://localhost/iiif/2/img-8664_202009/manifest.json', 'V2 Manifest ID is using new infrastructure changed')
         canvas = manifest['sequences'][0]['canvases'][0]
         self.assertEqual(canvas['@id'], 'https://iiif.archivelab.org/iiif/img-8664_202009/canvas', 'Expected canvas id to be the same')
         image = canvas['images'][0]['resource']
@@ -48,7 +48,7 @@ class TestManifests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         manifest = resp.json
 
-        self.assertEqual(manifest['@id'], 'https://localhost/iiif/fbf_3chords_1_/manifest.json', 'V2 Manifest ID is using new infrastructure changed')
+        self.assertEqual(manifest['@id'], 'https://localhost/iiif/2/fbf_3chords_1_/manifest.json', 'V2 Manifest ID is using new infrastructure changed')
         canvas = manifest['sequences'][0]['canvases'][0]
         self.assertEqual(canvas['@id'], 'https://iiif.archivelab.org/iiif/fbf_3chords_1_$0/canvas', 'Expected canvas id to be the same')
         image = canvas['images'][0]['resource']


### PR DESCRIPTION
# What Does this Do

This does several things. 

1. replaces the default redirect behavior so that versionless requests are proxied to the request for the latest presentation API version rather than redirecting as a 302. It does this by calling function related to the decorator of the latest API version.
2. makes version 2 manifests have an `@id` with the version number in it.
3. ensures the helper uses  the versionless url.
4. updates the docs.
5. udates or replaces tests to reflect these changes.





