### PR TITLE
Address Issue-102.

### DIFF
--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -487,12 +487,10 @@ def addThumbnails(manifest, identifier, files):
                 mimetype = "image/jpeg"
                 if file['name'].endswith('.png'):
                     mimetype = "image/png"
-
-                manifest.thumbnail.append({
-                    "id": f"{ARCHIVE}/download/{quote(identifier)}/{quote(file['name'])}",
-                    "type": "Image",
-                    "format": mimetype,
-                })
+                manifest.add_thumbnail(
+                    f"{ARCHIVE}/download/{quote(identifier)}/{quote(file['name'])}",
+                    format=mimetype,
+                )
     return manifest
 
 def sortDerivatives(metadata, includeVtt=False):

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -475,13 +475,24 @@ def addRendering(manifest, identifier, files):
 def addThumbnails(manifest, identifier, files):
     for file in files:
         if file['format'] == "Thumbnail" or file['format'] == "JPEG Thumb" or file['name'] == "__ia_thumb.jpg":
-            thumbnail_uri = quote(
-                file.get('name').split('/')[-1].replace('/','%2f')
-            )
-            # Forward solidus before thumbnail uri must always be %2f
-            manifest.create_thumbnail_from_iiif(
-                f"{IMG_SRV}/2/{identifier.strip()}%2f{thumbnail_uri}"
-            )
+            try:
+                thumbnail_uri = quote(
+                    file.get('name').split('/')[-1].replace('/','%2f')
+                )
+                # Forward solidus before thumbnail uri must always be %2f
+                manifest.create_thumbnail_from_iiif(
+                    f"{IMG_SRV}/2/{identifier.strip()}%2f{thumbnail_uri}"
+                )
+            except requests.HTTPError:
+                mimetype = "image/jpeg"
+                if file['name'].endswith('.png'):
+                    mimetype = "image/png"
+
+                manifest.thumbnail.append({
+                    "id": f"{ARCHIVE}/download/{quote(identifier)}/{quote(file['name'])}",
+                    "type": "Image",
+                    "format": mimetype,
+                })
     return manifest
 
 def sortDerivatives(metadata, includeVtt=False):

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -473,22 +473,16 @@ def addRendering(manifest, identifier, files):
                  })
 
 def addThumbnails(manifest, identifier, files):
-    thumbnails = []
-
     for file in files:
-        if file['format'] == "Thumbnail":
-            mimetype = "image/jpeg"
-            if file['name'].endswith('.png'):
-                mimetype = "image/png"
-
-            thumbnails.append({
-                "id": f"{ARCHIVE}/download/{quote(identifier)}/{quote(file['name'])}",
-                "type": "Image",
-                "format": mimetype,
-            })
-
-    if thumbnails:
-        manifest.thumbnail = thumbnails
+        if file['format'] == "Thumbnail" or file['format'] == "JPEG Thumb" or file['name'] == "__ia_thumb.jpg":
+            thumbnail_uri = quote(
+                file.get('name').split('/')[-1].replace('/','%2f')
+            )
+            # Forward solidus before thumbnail uri must always be %2f
+            manifest.create_thumbnail_from_iiif(
+                f"{IMG_SRV}/2/{identifier.strip()}%2f{thumbnail_uri}"
+            )
+    return manifest
 
 def sortDerivatives(metadata, includeVtt=False):
     """
@@ -535,7 +529,7 @@ def create_manifest3(identifier, domain=None, page=None):
     addMetadata(manifest, identifier, metadata['metadata'])
     addSeeAlso(manifest, identifier, metadata['files'])
     addRendering(manifest, identifier, metadata['files'])
-    addThumbnails(manifest, identifier, metadata['files'])
+    manifest = addThumbnails(manifest, identifier, metadata['files'])
 
     if mediatype == 'texts':
         # Get bookreader metadata (mostly for filenames and height / width of image)

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -473,8 +473,15 @@ def addRendering(manifest, identifier, files):
                  })
 
 def addThumbnails(manifest, identifier, files):
+    """Creates thumbnails based on files.
+
+    If file is intended to be a thumbnail based on format or name and it's not a derivative, the thumbnail is created from
+    Cantaloupe. If it's not, a service-less thumbnail is created and added to the manifest. Not sure why, but if file["source"]
+    is "derivative", the file doesn't seem to be available to Cantaloupe.
+
+    """
     for file in files:
-        if file['format'] == "Thumbnail" or file['format'] == "JPEG Thumb" or file['name'] == "__ia_thumb.jpg":
+        if file['format'] == "Thumbnail" or file['format'] == "JPEG Thumb" or file['name'] == "__ia_thumb.jpg" and file["source"] == "original":
             try:
                 thumbnail_uri = quote(
                     file.get('name').split('/')[-1].replace('/','%2f')
@@ -491,6 +498,14 @@ def addThumbnails(manifest, identifier, files):
                     f"{ARCHIVE}/download/{quote(identifier)}/{quote(file['name'])}",
                     format=mimetype,
                 )
+        elif file['format'] == "Thumbnail" or file['format'] == "JPEG Thumb" or file['name'] == "__ia_thumb.jpg":
+            mimetype = "image/jpeg"
+            if file['name'].endswith('.png'):
+                mimetype = "image/png"
+            manifest.add_thumbnail(
+                f"{ARCHIVE}/download/{quote(identifier)}/{quote(file['name'])}",
+                format=mimetype,
+            )
     return manifest
 
 def sortDerivatives(metadata, includeVtt=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask==3.1.0
 Flask-Caching==2.3.0
 Flask-Cors==5.0.0
 idna==3.10
-iiif-prezi3==2.0.0
+iiif-prezi3==2.0.1
 importlib_metadata==8.5.0
 internetarchive==5.0.4
 itsdangerous==2.2.0

--- a/tests/test_linking.py
+++ b/tests/test_linking.py
@@ -102,4 +102,4 @@ class TestLinking(unittest.TestCase):
 
 		# Thumbnail - thumbnail
         # 19 thumbs
-        self.assertEqual(len(manifest['thumbnail']), 19, f"Expected 19 thumbnails: {manifest['thumbnail']}") 
+        self.assertEqual(len(manifest['thumbnail']), 20, f"Expected 19 thumbnails: {manifest['thumbnail']}")

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -192,7 +192,7 @@ class TestManifests(unittest.TestCase):
         resp = self.test_app.get("/iiif/3/Waste-Management_Taster-Too-demo-2009/manifest.json")
         self.assertEqual(resp.status_code, 200)
         manifest = resp.json
-        self.assertEqual(len(manifest['thumbnail']),6, f"Expected 1 thumbnail, but got {len(manifest['thumbnail'])}")
+        self.assertEqual(len(manifest['thumbnail']),6, f"Expected 6 thumbnails, but got {len(manifest['thumbnail'])}.")
 
 ''' to test:
 kaled_jalil (no derivatives)

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -149,7 +149,7 @@ class TestManifests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         manifest = resp.json
         self.assertEqual(len(manifest['thumbnail']),17, f"Expected 15 thumbnails, but got {len(manifest['thumbnail'])}")
-        self.assertEqual(manifest['thumbnail'][0]['id'],"https://archive.org/download/steamboat-willie-16mm-film-scan-4k-lossless/steamboat-willie-16mm-film-scan-4k-lossless.thumbs/Steamboat%20Willie%20%5B16mm%20Film%20Scan%5D_ProRes%20%283400x2550%29_000001.jpg", f"Expected URL to be encoded")
+        self.assertEqual(manifest['thumbnail'][0]['id'],"https://iiif.archive.org/image/iiif/2/steamboat-willie-16mm-film-scan-4k-lossless%2fSteamboat%20Willie%20%5B16mm%20Film%20Scan%5D_ProRes%20%283400x2550%29.01_thumb.jpg/full/192,/0/default.jpg", f"Expected URL to be encoded")
 
         self.assertEqual(len(manifest['items']),1, f"Expected 1 canvas, but got {len(manifest['items'])}")
 

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -148,7 +148,7 @@ class TestManifests(unittest.TestCase):
         resp = self.test_app.get("/iiif/3/steamboat-willie-16mm-film-scan-4k-lossless/manifest.json")
         self.assertEqual(resp.status_code, 200)
         manifest = resp.json
-        self.assertEqual(len(manifest['thumbnail']),17, f"Expected 15 thumbnails, but got {len(manifest['thumbnail'])}")
+        self.assertEqual(len(manifest['thumbnail']),17, f"Expected 17 thumbnails, but got {len(manifest['thumbnail'])}")
         self.assertEqual(manifest['thumbnail'][0]['id'],"https://iiif.archive.org/image/iiif/2/steamboat-willie-16mm-film-scan-4k-lossless%2fSteamboat%20Willie%20%5B16mm%20Film%20Scan%5D_ProRes%20%283400x2550%29.01_thumb.jpg/full/192,/0/default.jpg", f"Expected URL to be encoded")
 
         self.assertEqual(len(manifest['items']),1, f"Expected 1 canvas, but got {len(manifest['items'])}")
@@ -188,6 +188,11 @@ class TestManifests(unittest.TestCase):
 
         self.assertNotEqual(manifest.get('behavior', ['']), ["auto-advance"], "Expected no auto-advance behavior on manifest with 1 canvas." )
 
+    def test_thumbnail_on_audio_item(self):
+        resp = self.test_app.get("/iiif/3/Waste-Management_Taster-Too-demo-2009/manifest.json")
+        self.assertEqual(resp.status_code, 200)
+        manifest = resp.json
+        self.assertEqual(len(manifest['thumbnail']),6, f"Expected 1 thumbnail, but got {len(manifest['thumbnail'])}")
 
 ''' to test:
 kaled_jalil (no derivatives)

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -148,7 +148,7 @@ class TestManifests(unittest.TestCase):
         resp = self.test_app.get("/iiif/3/steamboat-willie-16mm-film-scan-4k-lossless/manifest.json")
         self.assertEqual(resp.status_code, 200)
         manifest = resp.json
-        self.assertEqual(len(manifest['thumbnail']),15, f"Expected 15 thumbnails, but got {len(manifest['thumbnail'])}")
+        self.assertEqual(len(manifest['thumbnail']),17, f"Expected 15 thumbnails, but got {len(manifest['thumbnail'])}")
         self.assertEqual(manifest['thumbnail'][0]['id'],"https://archive.org/download/steamboat-willie-16mm-film-scan-4k-lossless/steamboat-willie-16mm-film-scan-4k-lossless.thumbs/Steamboat%20Willie%20%5B16mm%20Film%20Scan%5D_ProRes%20%283400x2550%29_000001.jpg", f"Expected URL to be encoded")
 
         self.assertEqual(len(manifest['items']),1, f"Expected 1 canvas, but got {len(manifest['items'])}")


### PR DESCRIPTION
# What Does this Do

This Addresses Issue-102 and ensures everything from Internet Archive has a thumbnail on the Manifest.  If a filename's format is `Thumbnail` or `Jpeg Thumb` or it's named `"__ia_thumb.jpg"`, the filename is used as a thumbnail. 

We then try to pass the thumbnail to Cantaloupe for processing.  If it's successful, we return the thumbnail with the service.  If it's not, we hard code things as was done previously.