### PR TITLE
Fixing helper links for Image API

### DIFF
--- a/iiify/templates/helper.html
+++ b/iiify/templates/helper.html
@@ -17,9 +17,9 @@
 
 <p>The manifest URL is: <a href="{{ uri }}/manifest.json">{{ uri }}/manifest.json</a></p>
 
-<p>The Image API URL for the full image is: <a href="https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/full/max/0/default.jpg">https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/full/max/0/default.jpg</a></p>
+<p>The Image API URL for the full image is: <a href="https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/full/max/0/default.jpg">https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/full/max/0/default.jpg</a></p>
 
-<p>The Image API info.json  for the image is: <a href="https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/info.json">https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/info.json</a></p>
+<p>The Image API info.json  for the image is: <a href="https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/info.json">https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/info.json</a></p>
 
     </body>
 </html>

--- a/iiify/templates/helpers/image.html
+++ b/iiify/templates/helpers/image.html
@@ -26,9 +26,9 @@
 
         <p>The IIIF manifest URL is: <a href="https://iiif.archive.org/iiif/{{ identifier }}/manifest.json">https://iiif.archive.org/iiif/{{ identifier }}/manifest.json</a></p>
 
-        <p>The Image API URL for the full image is: <a href="https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/full/max/0/default.jpg">https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/full/max/0/default.jpg</a></p>
+        <p>The Image API URL for the full image is: <a href="https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/full/max/0/default.jpg">https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/full/max/0/default.jpg</a></p>
 
-        <p>The Image API info.json  for the image is: <a href="https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/info.json">https://iiif.archive.org/image/iiif/{{ cantaloupe_id }}/info.json</a></p>
+        <p>The Image API info.json  for the image is: <a href="https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/info.json">https://iiif.archive.org/image/iiif/3/{{ cantaloupe_id }}/info.json</a></p>
 
         <h2>IIIF viewer options</h2>
         <ul>


### PR DESCRIPTION
Fixing the helpers as the versionless image URL doesn't work. Closes #101 