### PR TITLE
Init track list for multi-file audio items.

### DIFF
--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -587,6 +587,7 @@ def create_manifest3(identifier, domain=None, page=None):
         bookreader = requests.get(bookReaderURL).json()
         if 'error' in bookreader:
             # Image stack not found. Maybe a single image
+            print('yep')
             singleImage(metadata, identifier, manifest, uri)
         else:
             pageCount = 0
@@ -712,6 +713,8 @@ def create_manifest3(identifier, domain=None, page=None):
             slugged_id = normalised_id.replace(" ", "-")
             c_id = f"{URI_PRIFIX}/{identifier}/{slugged_id}/canvas"
             c = Canvas(id=c_id, label=normalised_id, duration=float(file['length']))
+
+            # if multiple files, also add a range
             if total_audio_files > 1:
                 track = top_range.make_range(
                     id = f"{URI_PRIFIX}/{identifier}/{slugged_id}/range",

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -705,7 +705,7 @@ def create_manifest3(identifier, domain=None, page=None):
         if total_audio_files > 1:
             top_range = manifest.make_range(
                 id=f"{URI_PRIFIX}/{identifier}/range/1",
-                label="Track List"
+                label={"en": ["Track List"]}
             )
         for file in [f for f in originals if f['format'] in AUDIO_FORMATS]:
             normalised_id = file['name'].rsplit(".", 1)[0]

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -701,7 +701,7 @@ def create_manifest3(identifier, domain=None, page=None):
             manifest.behavior = "auto-advance"
 
         # create the canvases for each original
-        total_audio_files = len([file for file in [f for f in originals if f['format'] in AUDIO_FORMATS]])
+        total_audio_files = len([f for f in originals if f['format'] in AUDIO_FORMATS])
         if total_audio_files > 1:
             top_range = manifest.make_range(
                 id=f"{URI_PRIFIX}/{identifier}/range/1",
@@ -716,8 +716,8 @@ def create_manifest3(identifier, domain=None, page=None):
             # if multiple files, also add a range
             if total_audio_files > 1:
                 track = top_range.make_range(
-                    id = f"{URI_PRIFIX}/{identifier}/{slugged_id}/range",
-                    label=file.get('title', slugged_id)
+                    id = f"{URI_PRIFIX}/{identifier}/{normalised_id}/range",
+                    label=file.get('title', normalised_id)
                 )
                 track.add_item(
                     CanvasRef(

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -716,7 +716,7 @@ def create_manifest3(identifier, domain=None, page=None):
             # if multiple files, also add a range
             if total_audio_files > 1:
                 track = top_range.make_range(
-                    id = f"{URI_PRIFIX}/{identifier}/{normalised_id}/range",
+                    id = f"{URI_PRIFIX}/{identifier}/{slugged_id}/range",
                     label=file.get('title', normalised_id)
                 )
                 track.add_item(

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -587,7 +587,6 @@ def create_manifest3(identifier, domain=None, page=None):
         bookreader = requests.get(bookReaderURL).json()
         if 'error' in bookreader:
             # Image stack not found. Maybe a single image
-            print('yep')
             singleImage(metadata, identifier, manifest, uri)
         else:
             pageCount = 0

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -17,3 +17,19 @@ class TestAudio(unittest.TestCase):
         manifest = resp.json
 
         self.assertEqual(len(manifest['items']),114,f"Expected 114 canvases but got: {len(manifest['items'])}") 
+
+    def test_multi_track_audio_gets_ranges(self):
+        resp = self.test_app.get("/iiif/Weirdos_demo-1978/manifest.json")
+        self.assertEqual(resp.status_code, 200)
+        manifest = resp.json
+
+        self.assertEqual(len(manifest["structures"]), 1, f"Expected a top level range to serve as the track list but got {len(manifest['items'])}")
+        self.assertEqual(manifest["structures"][0]["label"]["none"][0], "Track List", f"Expected a top level range to be labeled 'Track List' but got {manifest["structures"][0]["label"]["none"][0]}")
+        self.assertEqual(len(manifest["structures"][0]["items"]), 15, f"Expected 15 tracks but got {len(manifest["structures"][0]["items"])}")
+    
+    def test_single_track_audio_gets_no_ranges(self):
+        resp = self.test_app.get("/iiif/2021-04-06/manifest.json")
+        self.assertEqual(resp.status_code, 200)
+        manifest = resp.json
+
+        self.assertNotIn("structures", manifest, "Expected single file audio to have no structures or ranges.")

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -24,7 +24,7 @@ class TestAudio(unittest.TestCase):
         manifest = resp.json
 
         self.assertEqual(len(manifest["structures"]), 1, f"Expected a top level range to serve as the track list but got {len(manifest['items'])}")
-        self.assertEqual(manifest["structures"][0]["label"]["none"][0], "Track List", f"Expected a top level range to be labeled 'Track List' but got {manifest["structures"][0]["label"]["none"][0]}")
+        self.assertEqual(manifest["structures"][0]["label"]["en"][0], "Track List", f"Expected a top level range to be labeled 'Track List' but got {manifest["structures"][0]["label"]["en"][0]}")
         self.assertEqual(len(manifest["structures"][0]["items"]), 15, f"Expected 15 tracks but got {len(manifest["structures"][0]["items"])}")
     
     def test_single_track_audio_gets_no_ranges(self):


### PR DESCRIPTION
# What Does This Do

This adds a track list for audio works with multiple canvases.  The track list is called "Track List" as each of its ranges is named for the track.

If there is only 1 audio file, no track list is created.



