### PR TITLE
Address Issue-136:  Image Annotations and Annotation Page ids are not unique.

### DIFF
--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -677,13 +677,16 @@ def create_manifest3(identifier, domain=None, page=None):
                     imgId = f"{identifier}/{file['name']}".replace('/','%2f')
                     imgURL = f"{IMG_SRV}/3/{imgId}"
                     pageCount += 1
+                    slugged_id = file['name'].replace(" ", "-")
 
                     try:
-                        manifest.make_canvas_from_iiif(url=imgURL,
-                                                    id=f"{URI_PRIFIX}/{identifier}${pageCount}/canvas",
-                                                    label=f"{file['name']}",
-                                                    anno_page_id=f"{URI_PRIFIX}/{identifier}${pageCount}/annotationPage/1",
-                                                    anno_id=f"{URI_PRIFIX}/{identifier}${pageCount}/annotation/1")
+                        manifest.make_canvas_from_iiif(
+                            url=imgURL,
+                            id=f"{URI_PRIFIX}/{identifier}${pageCount}/canvas",
+                            label=f"{file['name']}",
+                            anno_page_id=f"{URI_PRIFIX}/{identifier}/{slugged_id}/page",
+                            anno_id=f"{URI_PRIFIX}/{identifier}/{slugged_id}/annotation"
+                        )
                     except requests.exceptions.HTTPError as error:
                         print (f'Failed to get {imgURL}')
                         manifest.make_canvas(label=f"Failed to load {file['name']} from Image Server",

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -682,8 +682,8 @@ def create_manifest3(identifier, domain=None, page=None):
                         manifest.make_canvas_from_iiif(url=imgURL,
                                                     id=f"{URI_PRIFIX}/{identifier}${pageCount}/canvas",
                                                     label=f"{file['name']}",
-                                                    anno_page_id=f"{uri}/annotationPage/1",
-                                                    anno_id=f"{uri}/annotation/1")
+                                                    anno_page_id=f"{URI_PRIFIX}/{identifier}${pageCount}/annotationPage/1",
+                                                    anno_id=f"{URI_PRIFIX}/{identifier}${pageCount}/annotation/1")
                     except requests.exceptions.HTTPError as error:
                         print (f'Failed to get {imgURL}')
                         manifest.make_canvas(label=f"Failed to load {file['name']} from Image Server",

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -20,5 +20,23 @@ class TestImages(unittest.TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertEqual("https://iiif.archive.org/image/iiif/2/jewishinterpreta00morg%2fjewishinterpreta00morg_jp2.zip%2fjewishinterpreta00morg_jp2%2fjewishinterpreta00morg_0267.jp2/info.json", resp.location, "Expected to be redirected to full JSON URl.")
 
+    def test_annotation_id_is_not_annotationpage_id(self):
+        resp = self.test_app.get("/iiif/3/Codex-Cuara/manifest.json?recache=true")
+        self.assertEqual(resp.status_code, 200)
+        manifest = resp.json
+        anno_page_ids = []
+        annotation_ids = []
+        for canvas in manifest['items']:
+            for anno_page in canvas['items']:
+                anno_page_ids.append(anno_page.get('id'))
+                for annotation in anno_page['items']:
+                    annotation_ids.append(annotation.get('id'))
+        
+        self.assertEqual(len(anno_page_ids), len(set(anno_page_ids)),
+                        "Some annotation page ids are duplicated")
+        self.assertEqual(len(annotation_ids), len(set(annotation_ids)),
+                        "Some annotation ids are duplicated")
+        overlap = set(anno_page_ids) & set(annotation_ids)
+        self.assertFalse(overlap, f"Some annotation ids are reused as annotation page ids: {overlap}")
 
-
+        


### PR DESCRIPTION
# What Does this Do

1. Adds a test to images to check that annotation ids and annotation page ids are unique.
2. Adds code to fix the current issue where they are not unique.