### PR TITLE
Only add __ia_thumb if only thumb.

### DIFF
--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -564,13 +564,28 @@ def addThumbnails(manifest, identifier, files):
     If the file appears to be a thumbnail (by format or name) attempt to create a IIIF thumbnail via Cantaloupe.
     If that fails or isn't possible, fall back to adding a static thumbnail.
     """
+    thumbnail_files = []
+    ia_thumb_files = []
+    
     for file in files:
         name = file.get("name", "")
         file_format = file.get("format", "")
-        is_thumbnail = file_format in {"Thumbnail", "JPEG Thumb"} or name == "__ia_thumb.jpg"
-        if not is_thumbnail:
-            continue
+        
+        if name == "__ia_thumb.jpg":
+            ia_thumb_files.append(file)
+        elif file_format in {"Thumbnail", "JPEG Thumb"}:
+            thumbnail_files.append(file)
 
+    files_to_process = []
+    
+    if thumbnail_files:
+        files_to_process = thumbnail_files
+    
+    elif ia_thumb_files:
+        files_to_process = ia_thumb_files
+    
+    for file in files_to_process:
+        name = file.get("name", "")
         encoded_name = quote(name.replace('/', '%2f'))
         # Forward solidus before thumbnail uri must always be %2f
         iiif_url = f"{IMG_SRV}/2/{identifier.strip()}%2f{encoded_name}"

--- a/tests/test_linking.py
+++ b/tests/test_linking.py
@@ -102,4 +102,4 @@ class TestLinking(unittest.TestCase):
 
 		# Thumbnail - thumbnail
         # 19 thumbs
-        self.assertEqual(len(manifest['thumbnail']), 20, f"Expected 19 thumbnails: {manifest['thumbnail']}")
+        self.assertEqual(len(manifest['thumbnail']), 19, f"Expected 19 thumbnails: {manifest['thumbnail']}")

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -148,7 +148,7 @@ class TestManifests(unittest.TestCase):
         resp = self.test_app.get("/iiif/3/steamboat-willie-16mm-film-scan-4k-lossless/manifest.json")
         self.assertEqual(resp.status_code, 200)
         manifest = resp.json
-        self.assertEqual(len(manifest['thumbnail']),17, f"Expected 17 thumbnails, but got {len(manifest['thumbnail'])}")
+        self.assertEqual(len(manifest['thumbnail']),16, f"Expected 16 thumbnails, but got {len(manifest['thumbnail'])}")
         self.assertEqual(manifest['thumbnail'][0]['id'],"https://iiif.archive.org/image/iiif/2/steamboat-willie-16mm-film-scan-4k-lossless%2fSteamboat%20Willie%20%5B16mm%20Film%20Scan%5D_ProRes%20%283400x2550%29.01_thumb.jpg/full/192,/0/default.jpg", f"Expected URL to be encoded")
 
         self.assertEqual(len(manifest['items']),1, f"Expected 1 canvas, but got {len(manifest['items'])}")
@@ -192,7 +192,7 @@ class TestManifests(unittest.TestCase):
         resp = self.test_app.get("/iiif/3/Waste-Management_Taster-Too-demo-2009/manifest.json")
         self.assertEqual(resp.status_code, 200)
         manifest = resp.json
-        self.assertEqual(len(manifest['thumbnail']),6, f"Expected 6 thumbnails, but got {len(manifest['thumbnail'])}.")
+        self.assertEqual(len(manifest['thumbnail']),5, f"Expected 5 thumbnails, but got {len(manifest['thumbnail'])}.")
 
     def test_part_of(self):
         resp = self.test_app.get("/iiif/3/cc4ia-Polar_Plunge_Promo_-_2018/manifest.json")


### PR DESCRIPTION
## What Does This Do

This only adds `__ia_thumb.jpg` as a thumbnail if it's the only thumb.

## How does it work

This makes two passes. 

1. First pass we identify and separates files into two categories:  ia_thumb_files: Files named "__ia_thumb.jpg" thumbnail_files: Files with format "Thumbnail" or "JPEG Thumb"
2. Then if there are any format-based thumbnail files, we only use those and ignore __ia_thumb.jpg
3. If not, we use __ia_thumb.jpg