### PR TITLE
Init thumbnail rework.

### DIFF
--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -571,11 +571,11 @@ def addThumbnails(manifest, identifier, files):
     """
     thumbnail_files = []
     ia_thumb_files = []
-    
+
     for file in files:
         name = file.get("name", "")
         file_format = file.get("format", "")
-        
+
         if name == "__ia_thumb.jpg":
             ia_thumb_files.append(file)
         elif file_format in {"Thumbnail", "JPEG Thumb"}:
@@ -591,16 +591,14 @@ def addThumbnails(manifest, identifier, files):
     
     for file in files_to_process:
         name = file.get("name", "")
-        encoded_name = quote(name.replace('/', '%2f'))
-        # Forward solidus before thumbnail uri must always be %2f
-        iiif_url = f"{IMG_SRV}/2/{identifier.strip()}%2f{encoded_name}"
-        try:
-            manifest.create_thumbnail_from_iiif(iiif_url)
-        except requests.HTTPError:
-            print(f"Failed to generate thumbnail from Cantaloupe: {iiif_url}")
-            mimetype = "image/png" if name.endswith(".png") else "image/jpeg"
-            static_url = f"{ARCHIVE}/download/{quote(identifier)}/{quote(name)}"
-            manifest.add_thumbnail(static_url, format=mimetype)
+        mimetype = "image/png" if name.endswith(".png") else "image/jpeg"
+        static_url = f"{ARCHIVE}/download/{quote(identifier)}/{quote(name)}"
+        manifest.add_thumbnail(
+            static_url,
+            format=mimetype,
+            **({"width": file["width"]} if "width" in file else {}),
+            **({"height": file["height"]} if "height" in file else {})
+        )
     return
 
 def addPartOfCollection(resource, collections, domain=None):

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -597,8 +597,8 @@ def addThumbnails(manifest, identifier, files, mediatype):
             manifest.add_thumbnail(
                 static_url,
                 format=mimetype,
-                **({"width": file["width"]} if "width" in file else {}),
-                **({"height": file["height"]} if "height" in file else {})
+                **({"width": file["width"]} if "width" in file else {"width": 192}),
+                **({"height": file["height"]} if "height" in file else {"height": 108})
             )
         else:
             encoded_name = quote(name.replace('/', '%2f'))

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -588,7 +588,7 @@ def addThumbnails(manifest, identifier, files, mediatype):
     
     elif ia_thumb_files:
         files_to_process = ia_thumb_files
-    av_types = ("audio", "video", "etree")
+    av_types = ("audio", "movies", "etree")
     for file in files_to_process:
         name = file.get("name", "")
         if mediatype in av_types:

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -563,7 +563,7 @@ def addRendering(manifest, identifier, files):
                  "format": rendering['format']
                  })
 
-def addThumbnails(manifest, identifier, files):
+def addThumbnails(manifest, identifier, files, mediatype):
     """Creates thumbnails based on files.
 
     If the file appears to be a thumbnail (by format or name) attempt to create a IIIF thumbnail via Cantaloupe.
@@ -588,17 +588,29 @@ def addThumbnails(manifest, identifier, files):
     
     elif ia_thumb_files:
         files_to_process = ia_thumb_files
-    
+    av_types = ("audio", "video", "etree")
     for file in files_to_process:
         name = file.get("name", "")
-        mimetype = "image/png" if name.endswith(".png") else "image/jpeg"
-        static_url = f"{ARCHIVE}/download/{quote(identifier)}/{quote(name)}"
-        manifest.add_thumbnail(
-            static_url,
-            format=mimetype,
-            **({"width": file["width"]} if "width" in file else {}),
-            **({"height": file["height"]} if "height" in file else {})
-        )
+        if mediatype in av_types:
+            mimetype = "image/png" if name.endswith(".png") else "image/jpeg"
+            static_url = f"{ARCHIVE}/download/{quote(identifier)}/{quote(name)}"
+            manifest.add_thumbnail(
+                static_url,
+                format=mimetype,
+                **({"width": file["width"]} if "width" in file else {}),
+                **({"height": file["height"]} if "height" in file else {})
+            )
+        else:
+            encoded_name = quote(name.replace('/', '%2f'))
+            # Forward solidus before thumbnail uri must always be %2f
+            iiif_url = f"{IMG_SRV}/2/{identifier.strip()}%2f{encoded_name}"
+            try:
+                manifest.create_thumbnail_from_iiif(iiif_url)
+            except requests.HTTPError:
+                print(f"Failed to generate thumbnail from Cantaloupe: {iiif_url}")
+                mimetype = "image/png" if name.endswith(".png") else "image/jpeg"
+                static_url = f"{ARCHIVE}/download/{quote(identifier)}/{quote(name)}"
+                manifest.add_thumbnail(static_url, format=mimetype)
     return
 
 def addPartOfCollection(resource, collections, domain=None):
@@ -671,7 +683,7 @@ def create_manifest3(identifier, domain=None, page=None):
     addMetadata(manifest, identifier, metadata['metadata'])
     addSeeAlso(manifest, identifier, metadata['files'])
     addRendering(manifest, identifier, metadata['files'])
-    addThumbnails(manifest, identifier, metadata['files'])
+    addThumbnails(manifest, identifier, metadata['files'], mediatype)
     addPartOfCollection(manifest, metadata.get('metadata').get('collection', []), domain)
 
     if mediatype == 'texts':

--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -340,7 +340,7 @@ def create_manifest(identifier, domain=None, page=None):
             if page:
                 manifest['sequences'][0]['canvases'].append(
                     manifest_page(
-                        identifier = f"{IMG_SRV}/2/{cantaloupe_resolver(f"{identifier}${page}", metadata=resp)}",
+                        identifier = f"{IMG_SRV}/2/{cantaloupe_resolver(identifier + '$' + str(page), metadata=resp)}",
                         label=data['pageNums'][page],
                         width=data['pageWidths'][page],
                         height=data['pageHeights'][page],
@@ -352,7 +352,7 @@ def create_manifest(identifier, domain=None, page=None):
             for page in range(0, len(data.get('leafNums', []))):
                 manifest['sequences'][0]['canvases'].append(
                     manifest_page(
-                        identifier = f"{IMG_SRV}/2/{cantaloupe_resolver(f"{identifier}${page}", metadata=resp)}",
+                        identifier = f"{IMG_SRV}/2/{cantaloupe_resolver(identifier + '$' + str(page), metadata=resp)}",
                         label=data['pageNums'][page],
                         width=data['pageWidths'][page],
                         height=data['pageHeights'][page],
@@ -594,12 +594,17 @@ def addThumbnails(manifest, identifier, files, mediatype):
         if mediatype in av_types:
             mimetype = "image/png" if name.endswith(".png") else "image/jpeg"
             static_url = f"{ARCHIVE}/download/{quote(identifier)}/{quote(name)}"
-            manifest.add_thumbnail(
-                static_url,
-                format=mimetype,
-                **({"width": file["width"]} if "width" in file else {"width": 192}),
-                **({"height": file["height"]} if "height" in file else {"height": 108})
-            )
+
+            if mediatype == "movies":
+                # Videos should not get height and width
+                manifest.add_thumbnail(static_url, format=mimetype)
+            elif mediatype in ("audio", "etree"):
+                manifest.add_thumbnail(
+                    static_url,
+                    format=mimetype,
+                    **({"width": file["width"]} if "width" in file else {"width": 192}),
+                    **({"height": file["height"]} if "height" in file else {"height": 108})
+                )
         else:
             encoded_name = quote(name.replace('/', '%2f'))
             # Forward solidus before thumbnail uri must always be %2f

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -149,7 +149,7 @@ class TestManifests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         manifest = resp.json
         self.assertEqual(len(manifest['thumbnail']),16, f"Expected 16 thumbnails, but got {len(manifest['thumbnail'])}")
-        self.assertEqual(manifest['thumbnail'][0]['id'],"https://iiif.archive.org/image/iiif/2/steamboat-willie-16mm-film-scan-4k-lossless%2fSteamboat%20Willie%20%5B16mm%20Film%20Scan%5D_ProRes%20%283400x2550%29.01_thumb.jpg/full/192,/0/default.jpg", f"Expected URL to be encoded")
+        self.assertEqual(manifest['thumbnail'][0]['id'],"https://archive.org/download/steamboat-willie-16mm-film-scan-4k-lossless/Steamboat%20Willie%20%5B16mm%20Film%20Scan%5D_ProRes%20%283400x2550%29.01_thumb.jpg", f"Expected URL to be encoded")
 
         self.assertEqual(len(manifest['items']),1, f"Expected 1 canvas, but got {len(manifest['items'])}")
 

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -148,10 +148,9 @@ class TestManifests(unittest.TestCase):
         resp = self.test_app.get("/iiif/3/steamboat-willie-16mm-film-scan-4k-lossless/manifest.json")
         self.assertEqual(resp.status_code, 200)
         manifest = resp.json
-        self.assertEqual(len(manifest['thumbnail']),16, f"Expected 16 thumbnails, but got {len(manifest['thumbnail'])}")
+        self.assertEqual(len(manifest['thumbnail']),1, f"Expected 1 thumbnails, but got {len(manifest['thumbnail'])}")
         self.assertEqual(manifest['thumbnail'][0]['id'],"https://archive.org/download/steamboat-willie-16mm-film-scan-4k-lossless/Steamboat%20Willie%20%5B16mm%20Film%20Scan%5D_ProRes%20%283400x2550%29.01_thumb.jpg", f"Expected URL to be encoded")
-
-        self.assertEqual(len(manifest['items']),1, f"Expected 1 canvas, but got {len(manifest['items'])}")
+        self.assertEqual(manifest['thumbnail'][0]['id'],"https://iiif.archive.org/image/iiif/2/steamboat-willie-16mm-film-scan-4k-lossless%2fSteamboat%20Willie%20%5B16mm%20Film%20Scan%5D_ProRes%20%283400x2550%29.01_thumb.jpg/full/192,/0/default.jpg", f"Expected URL to be encoded")
 
     def test_hd_manifest(self):
         resp = self.test_app.get("/iiif/3/cc4ia-Polar_Plunge_Promo_-_2018/manifest.json")

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -149,7 +149,6 @@ class TestManifests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         manifest = resp.json
         self.assertEqual(len(manifest['thumbnail']),1, f"Expected 1 thumbnails, but got {len(manifest['thumbnail'])}")
-        self.assertEqual(manifest['thumbnail'][0]['id'],"https://archive.org/download/steamboat-willie-16mm-film-scan-4k-lossless/Steamboat%20Willie%20%5B16mm%20Film%20Scan%5D_ProRes%20%283400x2550%29.01_thumb.jpg", f"Expected URL to be encoded")
         self.assertEqual(manifest['thumbnail'][0]['id'],"https://iiif.archive.org/image/iiif/2/steamboat-willie-16mm-film-scan-4k-lossless%2fSteamboat%20Willie%20%5B16mm%20Film%20Scan%5D_ProRes%20%283400x2550%29.01_thumb.jpg/full/192,/0/default.jpg", f"Expected URL to be encoded")
 
     def test_hd_manifest(self):


### PR DESCRIPTION
#  What Does This Do?

Skips Cantaloupe for audio / video thumbnails and fixes [Issue-141](https://github.com/internetarchive/iiif/issues/141).
Manifest generation was slow for items with many audio/video files (e.g. taboca_201002_03, 251 canvases) because every thumbnail  (including AV thumbnails) were routed through Cantaloupe's IIIF image service via create_thumbnail_from_iiif. For AV items this is unnecessary round-trip overhead per file and a needless dependency on the image server for content that isn't an image derivative.

This change runs things through addThumbnails based on mediatype:                                                        
                                                                                                            
* movies, audio, etree: build the thumbnail directly from a static archive.org/download/... URL instead of calling Cantaloupe. Movies get no explicit width/height; audio/etree get width/height from file metadata if present, otherwise a 192×108 default.                                                                  
* Everything else (images, texts, etc.): unchanged. It still goes through Cantaloupe, but now falls back to the same static-URL approach 